### PR TITLE
ruby/metal: Update to librashader ABI 2

### DIFF
--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -282,11 +282,6 @@ struct VideoMetal : VideoDriver, Metal {
     
     _viewportSize.x = width;
     _viewportSize.y = height;
-
-    _libraViewport.width = (uint32_t) width;
-    _libraViewport.height = (uint32_t) height;
-    _libraViewport.x = 0;
-    _libraViewport.y = 0;
     
     _outputX = (_viewWidth - width) / 2;
     _outputY = (_viewHeight - height) / 2;
@@ -343,8 +338,8 @@ private:
     /// consisting of the pixel buffer from the emulator, onto a texture the same size as our eventual output,
     /// `_renderTargetTexture`. Then it calls into librashader, which performs postprocessing onto the same
     /// output texture. Then for the second render pass here, we composite the output texture within ares's viewport.
-    /// We need this last pass because librashader expects the viewport to be the same size as the output texture,
-    /// which is not the case for ares.
+    /// We defer this second pass because it is performed directly onto the drawable texture, which we want to delay
+    /// acquiring for as long as possible.
     
     dispatch_semaphore_wait(_semaphore, DISPATCH_TIME_FOREVER);
 
@@ -384,7 +379,7 @@ private:
         [renderEncoder endEncoding];
         
         if (_filterChain) {
-          _libra.mtl_filter_chain_frame(&_filterChain, commandBuffer, frameCount, sourceTexture, _libraViewport, _renderTargetTexture, nil, nil);
+          _libra.mtl_filter_chain_frame(&_filterChain, commandBuffer, frameCount, sourceTexture, _renderTargetTexture, nil, nil, nil);
         }
         
         //this call will block the current thread/queue if a drawable is not yet available

--- a/ruby/video/metal/metal.hpp
+++ b/ruby/video/metal/metal.hpp
@@ -99,6 +99,5 @@ struct Metal {
   libra_instance_t _libra;
   libra_shader_preset_t _preset;
   libra_mtl_filter_chain_t _filterChain;
-  libra_viewport_t _libraViewport;
   bool initialized = false;
 };


### PR DESCRIPTION
We elect to just remove all usage of libra_viewport_t for Metal, since the current rendering path conforms better to recommended Metal patterns than passing the drawable texture directly to librashader would.